### PR TITLE
app.ts 路徑標錯

### DIFF
--- a/guide/settings.md
+++ b/guide/settings.md
@@ -148,7 +148,7 @@ VITE_APP_TITLE = ElementAdmin
 
 ### 配置文件路径
 
-[src/config/app.ts](https://github.com/kailong321200875/vue-element-plus-admin/blob/master/src/config/app.ts)
+[src/store/modules/app.ts](https://github.com/kailong321200875/vue-element-plus-admin/blob/master/src/store/modules/app.ts)
 
 ### 说明
 


### PR DESCRIPTION
如題可能是後來檔案位置有變動，用原本的路徑找不到，然後才發現路徑是不一樣的